### PR TITLE
fix: introduce a warning log level method

### DIFF
--- a/src/client/LoggerClient.ts
+++ b/src/client/LoggerClient.ts
@@ -87,6 +87,20 @@ export default class LoggerClient {
   }
 
   /**
+   * Log a warning level event
+   *
+   * @param logArguments Rollbar.LogArgument
+   * @returns
+   */
+  public logWarning(...logArguments: LogArgument[]) {
+    if (this._disabled) {
+      return
+    }
+
+    this._loggerClient?.warning(...logArguments)
+  }
+
+  /**
    * Log an error level event
    *
    * @param logArguments Rollbar.LogArgument
@@ -119,13 +133,14 @@ export default class LoggerClient {
         fingerprint: error.name,
         operationName: operation.operationName,
       },
-      logLevel: isIdentityMismatchError ? 'warning' : 'error',
     })
 
-    /**
-     * Log a generic event since we're defining a custom `logLevel`
-     */
-    this._loggerClient?.log(error)
+    if (isIdentityMismatchError) {
+      this.logWarning(error)
+    } else {
+      this.logError(error)
+    }
+
     console.error(error, operation)
 
     this.resetPayload()


### PR DESCRIPTION
We're seeing some network errors get sent as 'info' level events. The `logLevel` isn't being picked up by the generic `log` event for whatever reason. This is same same but I'll look into the configuration more thoroughly when I integrate the user identification hooks.