### PR TITLE
fix: bundle in ES for the browser

### DIFF
--- a/src/client/package.browser.json
+++ b/src/client/package.browser.json
@@ -1,0 +1,8 @@
+{
+  "name": "@deal/logger-browser",
+  "version": "1.0.0",
+  "description": "Logger client for web",
+  "main": "cjs/index.js",
+  "module": "es/index.js",
+  "typings": "es/index.d.ts"
+}


### PR DESCRIPTION
#### Overview of changes

- Bundling in ESM and not bundling the dependencies (like `rollup`) allows our apps to tree shake this package. In practice this doesn't gain us much since `rollup` only ships a minified UMD module which includes both the server and browser code, but it makes it a clearer in the build manifest where the bundle size is coming from.

