### PR TITLE
feat: support initializing disabled logger client

### DIFF
--- a/src/client/LoggerClient.ts
+++ b/src/client/LoggerClient.ts
@@ -11,6 +11,18 @@ export default class LoggerClient {
   public errorHandler: Rollbar.ExpressErrorHandler | undefined
 
   public constructor(props: LoggerClientConfiguration) {
+    this._disabled = Boolean(props.disabled)
+    if (this._disabled) {
+      return
+    }
+    this.initLoggerClient(props)
+  }
+
+  private initLoggerClient(props: LoggerClientConfiguration) {
+    if (this._loggerClient) {
+      return
+    }
+
     const loggerClient = new Rollbar({
       captureUncaught: true,
       captureUnhandledRejections: true,

--- a/src/client/types/index.ts
+++ b/src/client/types/index.ts
@@ -6,6 +6,7 @@ export interface LoggerClientConfiguration {
   accessToken: string
   environment: string
   version: string | undefined
+  disabled: boolean | undefined
 }
 
 /**


### PR DESCRIPTION
#### Overview of changes

- Initializing a LoggerClient with `disabled` flag will prevent instantiating the underlying rollbar client
- Deprecating rollbar will involve passing `disabled: true` from each of the web apps